### PR TITLE
Quote ctags shell parameters, fix #3.

### DIFF
--- a/v-mode.el
+++ b/v-mode.el
@@ -405,12 +405,12 @@ Optional argument PATH ."
             (concat (file-name-directory v-executable) "vlib"))
           (ctags-params                 ;
             (concat  "ctags --languages=-v --langdef=v --langmap=v:.v "
-              "--regex-v=/[ \\t]*fn[ \\t]+(.*)[ \\t]+(.*)/\\2/f,function/ "
-              "--regex-v=/[ \\t]*struct[ \\t]+([a-zA-Z0-9_]+)/\\1/s,struct/ "
-              "--regex-v=/[ \\t]*interface[ \\t]+([a-zA-Z0-9_]+)/\\1/i,interface/ "
-              "--regex-v=/[ \\t]*type[ \\t]+([a-zA-Z0-9_]+)/\\1/t,type/ "
-              "--regex-v=/[ \\t]*enum[ \\t]+([a-zA-Z0-9_]+)/\\1/e,enum/ "
-              "--regex-v=/[ \\t]*module[ \\t]+([a-zA-Z0-9_]+)/\\1/m,module/ " ;
+              "--regex-v='/[ \\t]*fn[ \\t]+(.*)[ \\t]+(.*)/\\2/f,function/' "
+              "--regex-v='/[ \\t]*struct[ \\t]+([a-zA-Z0-9_]+)/\\1/s,struct/' "
+              "--regex-v='/[ \\t]*interface[ \\t]+([a-zA-Z0-9_]+)/\\1/i,interface/' "
+              "--regex-v='/[ \\t]*type[ \\t]+([a-zA-Z0-9_]+)/\\1/t,type/' "
+              "--regex-v='/[ \\t]*enum[ \\t]+([a-zA-Z0-9_]+)/\\1/e,enum/' "
+              "--regex-v='/[ \\t]*module[ \\t]+([a-zA-Z0-9_]+)/\\1/m,module/' " ;
               "-e -R . " packages-path)))
     (when (file-exists-p packages-path)
       (let ((oldir default-directory))


### PR DESCRIPTION
### Brief summary of what the changes does

Quote the regexes in the command line invocation of ctags to make it a valid Bash command.

### Checklist

Please confirm with `x`:

- [x] I own the copyright to the submitted changes and indemnify `v-mode` from any copyright claim that might result from my not being the authorized copyright holder.
- [x] I've read [CONTRIBUTING.md](https://github.com/damon-kwok/v-mode/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [ ] My elisp byte-compiles cleanly
- [ ] `M-x checkdoc` is happy with my docstrings
- [ ] I have confirmed some of these without doing them
