### PR TITLE
Make dash and hydra optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,13 @@ it's too simple to need any).
   ("C-c C-f" . v-format-buffer)
   :mode ("\\.v?v\\.vsh\\'" . 'v-mode))
 ```
+
+### Manually
+Either copy `v-mode.el` to some directory in your [`load-path`](https://www.emacswiki.org/emacs/LoadPath), or [add this directory to it](https://www.emacswiki.org/emacs/LoadPath#h5o-1), then put the following in your [`.emacs`](https://www.emacswiki.org/emacs/InitFile#init_file):
+```elisp
+;;; V.
+(autoload 'v-mode "v-mode" "" t)
+(setq auto-mode-alist
+      (cons '("\\(\\.v\\|\\.vv\\|\\.vsh\\)$" . v-mode) auto-mode-alist))
+```
+`v-mode` will set the buffer encoding to `utf-8` by itself.

--- a/v-mode.el
+++ b/v-mode.el
@@ -46,14 +46,11 @@
 ;;
 ;;; Code:
 
-(require 'cl-lib)
-(require 'subr-x)
-(require 'js)
-(require 'dash)
-(require 'xref)
-(require 'hydra)
-(require 'imenu)
-(require 'easymenu)
+;; Load these packages if available, but do not fail otherwise:
+(require 'dash  nil 'noerror)
+(require 'hydra nil 'noerror)
+
+(require 'js) ;; For js-indent-line.
 
 (defvar v-mode-hook nil)
 
@@ -356,39 +353,43 @@ Optional argument PATH ."
     \\_/
 ")
 
-(defhydra v-hydra-menu
-  (:color blue
-    :hint none)
-  "
+(if (fboundp 'defhydra)
+    (progn
+      (defhydra v-hydra-menu
+        (:color blue
+                :hint none)
+        "
 %s(v-banner-default)
   Project     |  _i_: Init      _u_: Update     _o_: v.mod
               |  _b_: Build     _r_: Run
   Community   |  _1_: News      _2_: Discord    _3_: OpenIssue
               |  _4_: Tutorial  _5_: Awesome-V  _6_: Sponsors  _0_: Contribute
   _q_: Quit"                            ;
-  ("b" v-project-build "Build")
-  ("r" v-project-run "Run")
-  ("o" v-project-open "Open v.mod")
-  ("i" v-project-init "v init")
-  ("u" v-project-update "v udate")
-  ("1" (v-run-command "xdg-open https://twitter.com/v_language") "News")
-  ("2" (v-run-command "xdg-open https://discord.gg/vlang") "Discord")
-  ("3" (v-run-command "xdg-open https://github.com/vlang/v/issues")
-    "Open an issue")
-  ("4" (v-run-command
-         "xdg-open https://github.com/vlang/v/blob/master/doc/docs.md") "Docs")
-  ("5" (v-run-command "xdg-open https://github.com/vlang/awesome-v")
-    "Awesome-V")
-  ("6" (v-run-command "xdg-open https://patreon.com/vlang") "Supporter")
-  ("0" (v-run-command
-         "xdg-open https://github.com/vlang/v/blob/master/CONTRIBUTING.md")
-    "Contribute")
-  ("q" nil "Quit"))
+        ("b" v-project-build "Build")
+        ("r" v-project-run "Run")
+        ("o" v-project-open "Open v.mod")
+        ("i" v-project-init "v init")
+        ("u" v-project-update "v udate")
+        ("1" (v-run-command "xdg-open https://twitter.com/v_language") "News")
+        ("2" (v-run-command "xdg-open https://discord.gg/vlang") "Discord")
+        ("3" (v-run-command "xdg-open https://github.com/vlang/v/issues")
+         "Open an issue")
+        ("4" (v-run-command
+              "xdg-open https://github.com/vlang/v/blob/master/doc/docs.md") "Docs")
+        ("5" (v-run-command "xdg-open https://github.com/vlang/awesome-v")
+         "Awesome-V")
+        ("6" (v-run-command "xdg-open https://patreon.com/vlang") "Supporter")
+        ("0" (v-run-command
+              "xdg-open https://github.com/vlang/v/blob/master/CONTRIBUTING.md")
+         "Contribute")
+        ("q" nil "Quit"))
 
-(defun v-menu ()
-  "Open v hydra menu."
-  (interactive)
-  (v-hydra-menu/body))
+      (defun v-menu ()
+        "Open v hydra menu."
+        (interactive)
+        (v-hydra-menu/body))
+      )
+  )
 
 (defun v-build-tags ()
   "Build tags for current project."


### PR DESCRIPTION
### Brief summary of what the changes does

`v-mode` can work fine without those packages.
This version uses them if available, and if not, all the other features still work.

This also makes it very easy to install manually, and I’ve added instructions for that to `README.md`.

### Checklist

Please confirm with `x`:

- [x] I own the copyright to the submitted changes and indemnify `v-mode` from any copyright claim that might result from my not being the authorized copyright holder.
- [x] I've read [CONTRIBUTING.md](https://github.com/damon-kwok/v-mode/blob/master/CONTRIBUTING.md)
- [ ] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I have confirmed some of these without doing them
