### PR TITLE
Add a customise face for the careful keywords.

### DIFF
--- a/v-mode.el
+++ b/v-mode.el
@@ -133,6 +133,14 @@
   :type '(repeat string)
   :group 'v-mode)
 
+(defface v-mode-careful-keywords-face
+  '((((background light)) :inherit font-lock-keyword-face :weight thin :slant italic :background "#d8d8d8")
+    (((background dark)) :inherit font-lock-keyword-face :weight thin :slant italic :background "#404040"))
+  "Face `v-mode' uses to highlight keywords that need careful use."
+  :tag "V Careful Keywords"
+  :group 'v-mode)
+(defvar v-mode-careful-keywords-face 'v-mode-careful-keywords-face)
+
 (defcustom v-builtin-keywords
   '("string" "bool"                         ;
      "i8" "i16" "int" "i64" "i128"          ;
@@ -194,8 +202,8 @@
      ;; builtin
      (,v-builtin-keywords-regexp . font-lock-builtin-face)
 
-     ;; careful
-     (,v-careful-keywords-regexp . font-lock-warning-face)
+     ;; ;; careful
+     (,v-careful-keywords-regexp . v-mode-careful-keywords-face)
 
      ;; @ # $
      ;; ("#\\(?:include\\|flag\\)" . 'font-lock-builtin-face)


### PR DESCRIPTION
### Brief summary of what the changes does

[Please write a quick summary of the changes.] 
It seems harsh to mark "careful" keywords with a warning so I added a face (derived from `font-lock-keyword-face`) to add some visual feedback for those keywords that supports light and dark themes. 

Since I suck at colours I added it as a custom so user's could modify the setting to their liking. 

### Checklist

Please confirm with `x`:

- [x] I own the copyright to the submitted changes and indemnify `v-mode` from any copyright claim that might result from my not being the authorized copyright holder.
- [x] I've read [CONTRIBUTING.md](https://github.com/damon-kwok/v-mode/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I have confirmed some of these without doing them
